### PR TITLE
Add fuseki yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,5 +39,5 @@ networks:
   default:
     name: vivo
   ucd-linked-data:
-    name: ${RP-NETWORK:-ucd-linked-data}
+    name: ucd-linked-data
     external: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 #! /usr/bin/env yml-docker-compose.sh
-version: '3'
+version: '3.5'
 services:
 
   vivo-solr:
@@ -24,6 +24,9 @@ services:
       - vivo-solr
     ports:
       - 8080:8080
+    networks:
+      - default
+      - ucd-linked-data
 
 volumes:
   vivo-solr-data:
@@ -31,3 +34,10 @@ volumes:
   vivo-content-tdb:
   vivo-upgrade-data:
   vivo-uploads-data:
+
+networks:
+  default:
+    name: vivo
+  ucd-linked-data:
+    name: ${RP-NETWORK:-ucd-linked-data}
+    external: true

--- a/ucd-linked-data.yml
+++ b/ucd-linked-data.yml
@@ -1,0 +1,43 @@
+# This Example yml can start and external FUSKEKI instance
+
+# I use this to manage the containers
+# alias ld-dc="docker-compose -p ucd-linked-data -f $(pwd)/ucd-linked-data.yml"
+
+# Then `ld-dc up -d` for example.
+
+# This compose file shoud have reasonable defaults, but
+# updates to .env (eg FUSEKI_VERSION=foo) will update the startup
+
+# A complete .env file might look like:
+#ADMIN_PASSWORD=quinnisgreat
+#JVM_ARGS=-Xmx4g
+#FUSEKI_EXTERNAL_PORT=6030
+#FUSEKI_VERSION=jena-3.15-c.0.0.3
+#KAFKA_ENABLED=false
+
+# The ENDPOINT Associated w/ the default is
+#FUSEKI_ENDPOINT=http://admin:quinnisgreat@fuseki:3030/{database}
+
+
+version: '3.5'
+
+services:
+  fuseki:
+    image: ucdlib/rp-ucd-fuseki:${FUSEKI_VERSION:-latest}
+    environment:
+      - JVM_ARGS=${JVM_ARGS:- -Xmx4g}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-quinnisgreat}
+      - KAFKA_ENABLED=${KAFKA_ENABLED:-false}
+    volumes:
+      - fuseki-data:/fuseki
+      - ./staging:/staging
+    ports:
+      - ${FUSEKI_EXTERNAL_PORT:-3030}:3030
+
+volumes:
+  fuseki-data:
+    driver: local
+
+networks:
+  default:
+    name: ${RP-NETWORK:-ucd-linked-data}

--- a/ucd-linked-data.yml
+++ b/ucd-linked-data.yml
@@ -40,4 +40,4 @@ volumes:
 
 networks:
   default:
-    name: ${RP-NETWORK:-ucd-linked-data}
+    name: ucd-linked-data


### PR DESCRIPTION
This PR adds a more complete external fuseki setip. Includes an example YML file, and adds a shared network.  

I know this goes against @jrmerz one-directory / one compose file setup, I can move to it's own directory if needed.